### PR TITLE
fix(no-extra-parens): ignore multiline jsx

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -34,7 +34,7 @@ module.exports = {
     "no-extra-boolean-cast": ["error"],
 
     // don't add unecessary parens
-    "no-extra-parens": ["error"],
+    "no-extra-parens": ["error", { ignoreJSX: "multi-line" }],
 
     // bruh, it's 2021
     "no-var": ["error"],


### PR DESCRIPTION
before: 

```tsx
render(
  () => ( // this would throw an error
    <Router>
      <App />
    </Router>
  ),
  document.getElementById("root") as HTMLElement
);
```

after: 

```tsx
render(
  () => ( // would be ok to do this
    <Router>
      <App />
    </Router>
  ),
  document.getElementById("root") as HTMLElement
);
```